### PR TITLE
Added fail/success message to example script

### DIFF
--- a/tests/curl/post.php
+++ b/tests/curl/post.php
@@ -21,5 +21,11 @@
 	curl_setopt($ch, CURLOPT_POSTFIELDS,$data_json);
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 	$response  = curl_exec($ch);
+	if($response === false){
+		echo('Error: ' . curl_error($ch));
+	}
+	else{
+        	echo('Operation successful');
+	}
 	curl_close($ch);
 ?>


### PR DESCRIPTION
Issue #41: I found the problem, why the inital example script didn'T work for me. My Installation is only accessable via ssl, by default php is checking the certificate, in my case the check failed, and so the script failed silently. I added a fail sucess message at the end, which could have made the debuging in this case easier. (would also be good to have it in the other example scripts)