### PR TITLE
Fix for only temperature/humidity chart

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -713,7 +713,7 @@
 
 			drawableLines = [];
 			if(dataLines.length < 1) {
-				$.each(data, function (index, item) {
+				$.each(data.logs, function (index, item) {
 					line1.push([item.createdAt, parseFloat(item.temperature)])
 					line2.push([item.createdAt, parseFloat(item.humidity)])
 				});


### PR DESCRIPTION
# Pull Request

## Description
If datatype is only humidity and temperature (not free defined datatypes) the charts remain empty. 
Tested with Nextcloud 14 on Ubuntu 18.04

## Ozzie Isaacs

* Ref Issues: None
