### PR TITLE
Fix for spaming nextcloud error log

### DIFF
--- a/lib/LogExtended.php
+++ b/lib/LogExtended.php
@@ -65,8 +65,6 @@ class LogExtended extends Entity implements \JsonSerializable {
 			$this->addType('value', 'float');
 			$this->dataTypeId = $data->dataTypeId;
 			$this->value = $data->value;
-			$this->short = $data->short;
-			$this->type = $data->type;
 	}
 
 	public function jsonSerialize() {


### PR DESCRIPTION
# Pull request

## Description
If data with custom datatypes is pushed to the server the server creates entries like the the following:
"reqId":"xxxxxxxxxxxxxxxxxxxxxxxx","level":3,"time":"2018-12-28T17:27:41+00:00","remoteAddr":"127.0.0.1","user":"xxxxx","app":"PHP","method":"POST","url":"\/nextcloud\/index.php\/apps\/sensorlogger\/showDeviceData\/2","message":"Undefined property: stdClass::$short at \/var\/www\/html\/nextcloud\/apps\/sensorlogger\/lib\/LogExtended.php#68","userAgent":"Mozilla\/5.0 (X11; Ubuntu; Linux x86_64; rv:64.0) Gecko\/20100101 Firefox\/64.0","version":"15.0.0.10"}

This fix prevents this.

## Author(s)
Ozzie Isaacs

* Ref Issues: 
I didn't create one