### PR TITLE
Graphs with only "zeros" as data aren't shown

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -640,7 +640,7 @@
 							var xaxis = item.createdAt;
 							var ydata = item.data[i];
 
-							if (ydata && ydata.value) {
+							if (ydata && 'value' in ydata) {
 								ydata = ydata.value;
 								dataLines[i].push([xaxis, parseFloat(ydata)])
 							}


### PR DESCRIPTION
# Pull request
Graphs with only "zeros" as data aren't shown
## Description
If you are having a sensor with one datatype which only contains zeros as data graph of this sensor isn't shown, because line (643) in script.js returns false:
if (ydata && ydata.value) {
This fix corrects it.

## Author(s)
Ozzie Isaacs

* Ref Issues: 
I did'n create one.