### PR TITLE
Fix sorting graphs label is buggy

### DIFF
--- a/lib/DataTypes.php
+++ b/lib/DataTypes.php
@@ -81,7 +81,7 @@ class DataTypes {
 			->leftJoin('sddt','sensorlogger_data_types','sdt', 'sdt.id = sddt.data_type_id')
 			->where('sddt.user_id = "'.$userId.'"')
 			->andWhere('sddt.device_id = "'.$deviceId.'" ')
-			->orderBy('sddt.id', 'ASC');
+			->orderBy('sddt.data_type_id', 'ASC');
 		$query->setMaxResults(100);
 		$result = $query->execute();
 


### PR DESCRIPTION
# Pull request
Fix sorting graphs label is buggy
## Description
If you have custom datatype like:
![grafik](https://user-images.githubusercontent.com/6438895/50725674-241c8880-1101-11e9-9a4a-09d976517f97.png)
The labels for sensor 3 will be in wrong order because the output for labeling the garph is sorted according to table id instead of data_type_id

## Author(s)
Ozzie Isaacs
* Ref Issues: 
I didn't create one